### PR TITLE
feat(rules): Included exception for @keframes children

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,10 @@ var escapeStringRegexp = require('escape-string-regexp');
 var plugin = postcss.plugin('postcss-selector-prefix', function (prefix) {
     return function (root) {
         root.walkRules(function (rule) {
+            // don't touch @keyframes children
+            if (rule.parent && rule.parent.name === 'keyframes') {
+                return;
+            }
             rule.selectors = rule.selectors.map(function (selector) {
                 // replace combinator selectors that can't be prefixed.
                 selector = selector.replace(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-selector-prefix",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "PostCSS plugin to add a selector prefix to all selectors.",
   "keywords": [
     "postcss",


### PR DESCRIPTION
Currently all rules (except already prefixed ones) get prefixed. This includes @keyframes what results into this broken code:
```css
@keyframes {
    .prefix from {
        color: red;
    }
    .prefix to {
        color: blue;
    }
}
```

So I added a check for each selectors parent on `keyframes` and a return statement to leave it without prefix.